### PR TITLE
Updates babel-eslint in _package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -28,7 +28,7 @@
     "wiredep": "^2.2.2",
 		"babel": "^5.2.3",
     "gulp-babel": "^5.1.0",
-	  "babel-eslint": "^3.0.1",
+	  "babel-eslint": "^4.1.8",
 	  "babelify": "^6.0.2",
     "browserify": "^10.0.0",
     "vinyl-source-stream": "^1.1.0"


### PR DESCRIPTION
Issue #5:
Reason: `gulp serve` fails.
Solution: update babel-eslint compatible with v.4.1.8
